### PR TITLE
Enable specifying empty bad characters in find-gadget.py script

### DIFF
--- a/find-gadgets.py
+++ b/find-gadgets.py
@@ -144,7 +144,7 @@ class Gadgetizer:
                     f.write(f"{gadget}\n")
 
 
-def add_missing_gadgets(ropper_addresses: set, in_file, outfile, bad_bytes=None, base_address=None):
+def add_missing_gadgets(ropper_addresses: set, in_file, outfile, bad_bytes, base_address=None):
     """ for w/e reason rp++ finds signficantly more gadgets, this function adds them to ropper's dump of all gadgets """
     rp = Path('~/.local/bin/rp-lin-x64').expanduser().resolve()
 
@@ -164,10 +164,10 @@ def add_missing_gadgets(ropper_addresses: set, in_file, outfile, bad_bytes=None,
 
         command = f'{rp} -r5 -f {in_file} --unique'
 
-        if bad_bytes is not None:
+        if bad_bytes:
             bad_bytes = ''.join([f"\\x{byte}" for byte in bad_bytes])
             command += f' --bad-bytes={bad_bytes}'
-        if base_address is not None:
+        if base_address:
             command += f' --va={base_address}'
 
         print(f"[bright_green][+][/bright_green] running '{command}'")
@@ -293,7 +293,7 @@ if __name__ == "__main__":
         "--bad-chars",
         help="space separated list of bad chars to omit from gadgets (default: 00)",
         default=["00"],
-        nargs="+",
+        nargs="*",
     )
     parser.add_argument(
         "-a",


### PR DESCRIPTION
This enables specifying that no bad characters exist by providing no arguments to the `-b` flag, e.g.,

    $ python3 find-gadgets.py -f file.exe  -b

Prior to this patch, specifying an empty bad characters list was not possible because `-b` expected at least one argument. Specifying `-b ""` would yield wrong results. For example:

    $ python3 find-gadgets.py -f QuoteDB.exe  -b ""
    
    ...
    [+] running '/home/kali/.local/bin/rp-lin-x64 -r5 -f QuoteDB.exe --unique --bad-bytes=\x'
    ...

    $ wc -l found-gadgets.txt                                        
    1032 found-gadgets.txt

Note that `rp-lin-x64` was invoked incorrectly with `--bad-bytes=\x` and only found 1032 gadgets. However, with this patch applied, 3081 gadgets are found:
    
    $ python3 find-gadgets.py -f QuoteDB.exe  -b
    
    [+] running '/home/kali/.local/bin/rp-lin-x64 -r5 -f QuoteDB.exe --unique'

    $ wc -l found-gadgets.txt                                           
    3081 found-gadgets.txt

The `QuoteDB.exe` binary is from https://github.com/bmdyy/quote_db
